### PR TITLE
fix: add NULL pointer validation in HASH HAL Start functions

### DIFF
--- a/platform/ext/target/stm/common/stm32u3xx/hal/Src/stm32u3xx_hal_hash.c
+++ b/platform/ext/target/stm/common/stm32u3xx/hal/Src/stm32u3xx_hal_hash.c
@@ -863,6 +863,12 @@ HAL_StatusTypeDef HAL_HASH_Start(HASH_HandleTypeDef *hhash, const uint8_t *const
     return HAL_ERROR;
   }
 
+  /* Validate buffer pointers */
+  if (((pInBuffer == NULL) && (Size > 0U)) || (pOutBuffer == NULL))
+  {
+    return HAL_ERROR;
+  }
+
   /* Check if peripheral is ready to start process */
   if (hhash->State == HAL_HASH_STATE_READY)
   {
@@ -942,6 +948,12 @@ HAL_StatusTypeDef HAL_HASH_Start_IT(HASH_HandleTypeDef *hhash, const uint8_t *co
     return HAL_ERROR;
   }
 
+  /* Validate buffer pointers */
+  if (((pInBuffer == NULL) && (Size > 0U)) || (pOutBuffer == NULL))
+  {
+    return HAL_ERROR;
+  }
+
   /* Check if peripheral is ready to start process or suspended */
   temp_state = hhash->State;
   if ((temp_state == HAL_HASH_STATE_READY) || (temp_state == HAL_HASH_STATE_SUSPENDED))
@@ -1006,6 +1018,12 @@ HAL_StatusTypeDef HAL_HASH_Start_DMA(HASH_HandleTypeDef *hhash, const uint8_t *c
 
   /* Check the hash handle allocation */
   if (hhash == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Validate buffer pointers */
+  if (((pInBuffer == NULL) && (Size > 0U)) || (pOutBuffer == NULL))
   {
     return HAL_ERROR;
   }


### PR DESCRIPTION
## Summary

Add NULL pointer validation for `pInBuffer` and `pOutBuffer` in three HASH HAL functions to prevent hard faults from null pointer dereference.

Fixes #47

## Problem

`HAL_HASH_Start()`, `HAL_HASH_Start_IT()`, and `HAL_HASH_Start_DMA()` validate only the `hhash` handle but not the `pInBuffer` or `pOutBuffer` parameters. A `NULL` `pInBuffer` with non-zero `Size` is stored in the handle state and later dereferenced:

- In the interrupt path (`HASH_WriteData_IT()`): `*(uint32_t *)inputaddr` where `inputaddr = 0`
- In the DMA path: the DMA transfer reads from address `0`

This causes a **hard fault / system crash** (denial of service). The issue is confirmed by AddressSanitizer.

## Fix

Return `HAL_ERROR` early when:
- `pInBuffer == NULL && Size > 0` (zero-length hash with `NULL` input is permitted)
- `pOutBuffer == NULL` (output buffer is always required)

Applied consistently to all three functions:

```c
/* Validate buffer pointers */
if (((pInBuffer == NULL) && (Size > 0U)) || (pOutBuffer == NULL))
{
    return HAL_ERROR;
}
```

This follows the same validation pattern used in other STM32 HAL drivers (e.g., `HAL_CRYP_Encrypt`).
